### PR TITLE
hardcode Ember.get()

### DIFF
--- a/lib/handlebars-inline-precompile-plugin.js
+++ b/lib/handlebars-inline-precompile-plugin.js
@@ -2,17 +2,16 @@
 'use strict';
 
 var HANDLEBARS = 'handlebars-inline-precompile';
-var GET = 'ember-metal/get';
 
 module.exports = function (Handlebars) {
   return function (babel) {
     var t = babel.types;
 
-    var compile = function (path, template, hbs, get) {
+    var compile = function (path, template, hbs) {
       var nameLookup = Handlebars.JavaScriptCompiler.prototype.nameLookup;
       Handlebars.JavaScriptCompiler.prototype.nameLookup = function (parent, name, type) {
         if (type === 'context') {
-          return [get, '(', parent, ', "', name, '")'];
+          return ['Ember.get(', parent, ', "', name, '")'];
         } else {
           const comp = nameLookup.call(this, parent, name, type);
           return comp;
@@ -48,7 +47,6 @@ module.exports = function (Handlebars) {
             path.remove();
             const importName = file.addImport('handlebars.runtime', 'default').name;
             file[HANDLEBARS] = importName;
-            file[GET] = file.addImport('ember-metal/get', "default").name;
           }
         },
 
@@ -67,7 +65,7 @@ module.exports = function (Handlebars) {
               throw file.buildCodeFrameError(argumentErrorMsg);
             }
             //console.log(`ce-template: ${template}`);
-            compile(path, template, file[HANDLEBARS], file[GET]);
+            compile(path, template, file[HANDLEBARS]);
           }
         },
 
@@ -85,7 +83,7 @@ module.exports = function (Handlebars) {
               return quasi.value.cooked;
             }).join("");
 
-            compile(path, template, file[HANDLEBARS], file[GET]);
+            compile(path, template, file[HANDLEBARS]);
           }
         }
       }


### PR DESCRIPTION
This is in support of getting to Yarn workspaces — https://github.com/movableink/canvas/pull/2670

I haven't quite pinned down the reason why, but for some reason, this is not correctly resolving `ember-metal/get` and we get `_default2` is not a function errors all over the place in email builder. 

We do not need to merge this — but, just want to make sure this is tracked. 

Do we know if there are any actively maintained libraries that do the same thing as this? 